### PR TITLE
WIP: Clang compile issues fixed.

### DIFF
--- a/Source/SIMPLib/CoreFilters/DataContainerReader.cpp
+++ b/Source/SIMPLib/CoreFilters/DataContainerReader.cpp
@@ -180,7 +180,7 @@ void DataContainerReader::dataCheck()
     return;
   }
 
-  DataContainerArray::Container& tempContainers = tempDCA->getDataContainers();
+  DataContainerArray::Container tempContainers = tempDCA->getDataContainers();
   for(DataContainer::Pointer container : tempContainers)
   {
     if(getOverwriteExistingDataContainers())

--- a/Source/SIMPLib/DataContainers/IDataStructureContainerNode.hpp
+++ b/Source/SIMPLib/DataContainers/IDataStructureContainerNode.hpp
@@ -93,7 +93,7 @@ public:
   IDataStructureContainerNode(const QString& name = "")
     : IDataStructureNode(name)
   {}
-  IDataStructureContainerNode(IDataStructureNode::WeakPointer parent, const QString& name = "")
+  IDataStructureContainerNode(ParentType* parent, const QString& name = "")
     : IDataStructureNode(parent, name)
   {}
   ~IDataStructureContainerNode() override = default;
@@ -111,7 +111,7 @@ public:
    * @brief Returns the names of all children nodes.
    * @return
    */
-  constexpr NameList getNamesOfChildren() const
+  NameList getNamesOfChildren() const
   {
     NameList names;
     for(const auto& child : m_ChildrenNodes)
@@ -125,7 +125,7 @@ public:
    * @brief Returns the DataArrayPaths of all descendants.
    * @return
    */
-  constexpr DataArrayPathList getDescendantPaths() const
+  DataArrayPathList getDescendantPaths() const
   {
     DataArrayPathList paths;
 
@@ -147,7 +147,7 @@ public:
    * @brief Returns a list of DataArrayPaths from both itself and all its descendants.
    * @return
    */
-  constexpr DataArrayPathList getAllPaths() const
+  DataArrayPathList getAllPaths() const
   {
     DataArrayPathList list = getDescendantPaths();
     list.push_front(getDataArrayPath());


### PR DESCRIPTION
+ IDataStructureContainerNode constructor takes a weakpointer but the parent class takes a raw pointer. Clang does not seem to figure that one out.

+ IDataStructureContainerNode: Issues with a few uses of constexpr that clang does not like.

+ DataContainerReader: Clang complains about binding a reference to a temp std::vector which makes sense.

These should be reviewed (especially the constructor) as I am not sure which way you wanted to go with the parent raw pointer. We could try locking the weakpointer and then getting the embedded pointer?

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>